### PR TITLE
Fix a bug that web socket heart beat is not set in client

### DIFF
--- a/BrowserMessageHandlers.js
+++ b/BrowserMessageHandlers.js
@@ -176,8 +176,16 @@ it will overwrite this file.
       if ($tw.wiki.tiddlerExists('$:/plugins/OokTech/MultiUser/Server Warning')) {
         $tw.wiki.deleteTiddler('$:/plugins/OokTech/MultiUser/Server Warning');
       }
+
       $tw.settings.heartbeat = $tw.settings.heartbeat || {};
-      $tw.settings.heartbeat.interval = $tw.settings.heartbeat.interval || 1000;
+
+      if (!$tw.settings.heartbeat.interval) {
+        var heartbeatTiddler = $tw.wiki.getTiddler("$:/WikiSettings/split/heartbeat") || {text: "{}"};
+        var heartbeat = JSON.parse(heartbeatTiddler.fields.text) || {};
+        $tw.settings.heartbeat["interval"] = heartbeat.interval || 1000;
+      }
+
+
       $tw.utils.toggleClass(document.body,"tc-dirty",false);
       // Clear the time to live timeout.
       clearTimeout($tw.settings.heartbeat.TTLID);


### PR DESCRIPTION
Setting heartbeat interval for the web socket server from the config file seems not working.  
It turns out that the ping-pong between the server and the client is initiated by the client, but the client does not have the config.  

I am not sure what is the elegant way of solving this problem.  Currently I pass the heartbeat interval from server to client via a tiddler named "Heatbeat".  The client reads in the tiddler and setup the ping-pong interval properly.