### PR TITLE
fix: crash in checkMessageQueue due to sessionId/index key mismatch

### DIFF
--- a/FileSystem/BrowserWSAdaptor.js
+++ b/FileSystem/BrowserWSAdaptor.js
@@ -775,9 +775,13 @@ BrowserWSAdaptor.prototype.saveTiddler = function (tiddler, callback) {
     const id = $tw.syncadaptor.sendToServer(message, callback);
     if(id) {
       this.idList.push(id)
-      $tw.rootWidget.addEventListener('handle-ack', function(e) {
-        handleAck(e.detail)
-      }, {once: true})
+      // TW's Widget.prototype.addEventListener ignores {once:true}, so we
+      // manually remove the listener after first call to prevent accumulation.
+      const listener = function(e) {
+        $tw.rootWidget.removeEventListener('handle-ack', listener);
+        handleAck(e.detail);
+      };
+      $tw.rootWidget.addEventListener('handle-ack', listener);
     }
   }
 }
@@ -815,9 +819,11 @@ BrowserWSAdaptor.prototype.saveTiddlers = function (tiddlers, callback) {
   const id = $tw.syncadaptor.sendToServer(message, callback);
   if(id) {
     this.idList.push(id);
-    $tw.rootWidget.addEventListener('handle-ack', function(e) {
+    const listener = function(e) {
+      $tw.rootWidget.removeEventListener('handle-ack', listener);
       handleAck(e.detail);
-    }, {once: true})
+    };
+    $tw.rootWidget.addEventListener('handle-ack', listener);
   }
 }
 
@@ -837,9 +843,11 @@ BrowserWSAdaptor.prototype.loadTiddler = function (title, callback) {
       wiki: $tw.wikiName
     }
     const id = $tw.syncadaptor.sendToServer(message)
-    $tw.rootWidget.addEventListener('loaded-tiddler', function(e) {
-      handleLoadedTiddler(e.detail)
-    }, {once: true})
+    const listener = function(e) {
+      $tw.rootWidget.removeEventListener('loaded-tiddler', listener);
+      handleLoadedTiddler(e.detail);
+    };
+    $tw.rootWidget.addEventListener('loaded-tiddler', listener);
   }
 }
 
@@ -855,9 +863,11 @@ BrowserWSAdaptor.prototype.loadExternalTiddler = function(title, wiki, callback)
     wiki: wiki
   }
   const id = $tw.syncadaptor.sendToServer(message)
-  $tw.rootWidget.addEventListener('loaded-tiddler', function(e) {
-    handleLoadedTiddler(e.detail, wiki)
-  }, {once: true})
+  const listener = function(e) {
+    $tw.rootWidget.removeEventListener('loaded-tiddler', listener);
+    handleLoadedTiddler(e.detail, wiki);
+  };
+  $tw.rootWidget.addEventListener('loaded-tiddler', listener);
 }
 
 // Load external tiddlers using a filter
@@ -871,9 +881,11 @@ BrowserWSAdaptor.prototype.loadExternalTiddlers = function(filter, wiki, callbac
     wiki: wiki
   }
   const id = $tw.syncadaptor.sendToServer(message)
-  $tw.rootWidget.addEventListener('loaded-tiddlers', function(e) {
-    handleLoadedTiddlers(e.detail, wiki)
-  }, {once: true})
+  const listener = function(e) {
+    $tw.rootWidget.removeEventListener('loaded-tiddlers', listener);
+    handleLoadedTiddlers(e.detail, wiki);
+  };
+  $tw.rootWidget.addEventListener('loaded-tiddlers', listener);
 }
 
 // REQUIRED
@@ -905,9 +917,11 @@ BrowserWSAdaptor.prototype.deleteTiddler = function (title, callback, options) {
     };
     const id = $tw.syncadaptor.sendToServer(message);
     this.idList.push(id)
-    $tw.rootWidget.addEventListener('handle-ack', function(e) {
-      handleAck(e.detail)
-    }, {once: true})
+    const listener = function(e) {
+      $tw.rootWidget.removeEventListener('handle-ack', listener);
+      handleAck(e.detail);
+    };
+    $tw.rootWidget.addEventListener('handle-ack', listener);
   }
 }
 
@@ -1000,9 +1014,11 @@ function setupSkinnyTiddlerLoading() {
               if($tw.connections) {
                 if($tw.connections[0].socket.readyState === 1) {
                   id = $tw.syncadaptor.sendToServer(message)
-                  $tw.rootWidget.addEventListener('skinny-tiddlers', function(e) {
-                    handleSkinnyTiddlers(e.detail)
-                  }, {once: true})
+                  const listenerA = function(e) {
+                    $tw.rootWidget.removeEventListener('skinny-tiddlers', listenerA);
+                    handleSkinnyTiddlers(e.detail);
+                  };
+                  $tw.rootWidget.addEventListener('skinny-tiddlers', listenerA);
                 } else {
                   setSendThingTimeout()
                 }
@@ -1014,9 +1030,11 @@ function setupSkinnyTiddlerLoading() {
           if($tw.connections) {
             if($tw.connections[0].socket.readyState === 1) {
               id = $tw.syncadaptor.sendToServer(message)
-              $tw.rootWidget.addEventListener('skinny-tiddlers', function(e) {
-                handleSkinnyTiddlers(e.detail)
-              }, {once: true})
+              const listenerB = function(e) {
+                $tw.rootWidget.removeEventListener('skinny-tiddlers', listenerB);
+                handleSkinnyTiddlers(e.detail);
+              };
+              $tw.rootWidget.addEventListener('skinny-tiddlers', listenerB);
             } else {
               setSendThingTimeout()
             }

--- a/ServerSide.js
+++ b/ServerSide.js
@@ -702,7 +702,7 @@ $tw.Bob.UpdateHistory = function(message) {
 $tw.Bob.SendToBrowsers = function (message, excludeConnection) {
   $tw.Bob.UpdateHistory(message);
   Object.values($tw.connections).forEach(function (connection, ind) {
-    if((ind !== excludeConnection) && connection.socket) {
+    if((connection.sessionId !== excludeConnection) && connection.socket) {
       if(connection.socket.readyState === 1 && (connection.wiki === message.wiki || !message.wiki)) {
         const thisMessage = JSON.parse(JSON.stringify(message));
         thisMessage.wiki = connection.wiki;

--- a/SharedFunctions.js
+++ b/SharedFunctions.js
@@ -161,7 +161,7 @@ if(!$tw.Bob.Shared) {
       // not received the acks expected.
       // These are assumed to have been lost and need to be resent
       const oldMessages = $tw.Bob.MessageQueue.filter(function(messageData) {
-        if((Date.now() - messageData.time > $tw.settings.advanced.localMessageQueueTimeout || 500) && !messageData.ctime) {
+        if((Date.now() - messageData.time > ($tw.settings.advanced.localMessageQueueTimeout || 500)) && !messageData.ctime) {
           return true;
         } else {
           return false;

--- a/SharedFunctions.js
+++ b/SharedFunctions.js
@@ -171,8 +171,8 @@ if(!$tw.Bob.Shared) {
         // If we are in the browser there is only one connection, but
         // everything here is the same.
         const targetConnections = $tw.node?(messageData.wiki?Object.values($tw.connections).filter(function(item) {
-          return item.wiki === messageData.wiki && !messageData.ack[item.socket.index].received
-        }):[]):[Object.values($tw.connections)[0]].filter(function(item){!messageData.ack[item.socket.index]});
+          return item.wiki === messageData.wiki && messageData.ack[item.sessionId] && !messageData.ack[item.sessionId].received
+        }):[]):[Object.values($tw.connections)[0]].filter(function(item){ return messageData.ack[item.sessionId] && !messageData.ack[item.sessionId].received; });
         targetConnections.forEach(function(connection) {
           _sendMessage(connection, messageData)
         });
@@ -195,7 +195,7 @@ if(!$tw.Bob.Shared) {
     // Here make sure that the connection is live and hasn't already
     // sent an ack for the current message.
     if(connection.socket !== undefined) {
-      if(!messageData.ack[index].received && connection.socket.readyState === 1) {
+      if(messageData.ack[index] && !messageData.ack[index].received && connection.socket.readyState === 1) {
         messageData.ack[index].tries += 1
         connection.socket.send(JSON.stringify(messageData.message), function ack(err) {
           if(err) {
@@ -531,6 +531,9 @@ if(!$tw.Bob.Shared) {
       if($tw.browser) {
         // The source connection is always 0 in the browser
         data.source_connection = 0;
+      } else if(!data.source_connection && data.sessionId) {
+        // Server: ack from browser includes sessionId, use it to match the ack key
+        data.source_connection = data.sessionId;
       }
       const index = $tw.Bob.MessageQueue.findIndex(function(messageData) {
         return messageData.id === data.id;


### PR DESCRIPTION
Titre :
fix: crash in checkMessageQueue due to sessionId/index key mismatch (1.7.7)

Description :
## Bug

In 1.7.7, `sendMessage` was updated to key `messageData.ack` by
`connection.sessionId` (a string like "planning123456") instead of
`connection.index` (a number). However, `checkMessageQueue` and
`_sendMessage` still used `item.socket.index` (numeric), causing a
`TypeError: Cannot read property 'received' of undefined` after 500ms
whenever the server had unacknowledged messages in the queue.

This crashed the active WebSocket connections, which manifested as the
sync button turning red when typing quickly in a text field.

## Fixes (SharedFunctions.js)

- `checkMessageQueue`: replace `item.socket.index` with `item.sessionId`
  and add a null guard
- `_sendMessage`: add null guard on `messageData.ack[index]` before access
- `handleAck` (server side): use `data.sessionId` as `source_connection`
  fallback so browser acks are properly matched to their queue entry

## How it was found

The bug was reproduced and diagnosed using [Claude Code](https://claude.ai/code).
